### PR TITLE
Added PointerUp/Down consume support;

### DIFF
--- a/src/tb/tb_widgets.h
+++ b/src/tb/tb_widgets.h
@@ -920,10 +920,10 @@ public:
 		this call and are not sure what the event will cause, use TBWidgetSafePointer to detect self deletion. */
 	bool InvokeEvent(TBWidgetEvent &ev);
 
-	void InvokePointerDown(int x, int y, int click_count, MODIFIER_KEYS modifierkeys, bool touch);
-	void InvokePointerUp(int x, int y, MODIFIER_KEYS modifierkeys, bool touch);
+	bool InvokePointerDown(int x, int y, int click_count, MODIFIER_KEYS modifierkeys, bool touch);
+	bool InvokePointerUp(int x, int y, MODIFIER_KEYS modifierkeys, bool touch);
 	void InvokePointerMove(int x, int y, MODIFIER_KEYS modifierkeys, bool touch);
-	void InvokeWheel(int x, int y, int delta_x, int delta_y, MODIFIER_KEYS modifierkeys);
+	bool InvokeWheel(int x, int y, int delta_x, int delta_y, MODIFIER_KEYS modifierkeys);
 
 	/** Invoke the EVENT_TYPE_KEY_DOWN and EVENT_TYPE_KEY_UP events on the currently focused widget.
 		This will also do some generic key handling, such as cycling focus on tab etc. */


### PR DESCRIPTION
Something useful for games is knowing when all input events are handled by the UI. The problem with TB is that it doesn't report handling of pointer up/down events.

It was a fairly simple change, simply changed the functions to return true if we have a captured/target widget, which is what we really want to know. We don't care if the event was actually handled at all, as long as we have a focused widget we shouldn't propagate the pointer event to the game.

PointerMoved events wouldn't be hard to support too but I find that the results would be a bit awkward to work with since they get handled for Hover targets too. I'm unsure if it's a good or bad idea to make PointerMoved report the same as PointerUp/Down, so any feedback would be appreciated.