### PR TITLE
Some fixes for building with fips build system

### DIFF
--- a/Demo/platform/glfw_extra_win.cpp
+++ b/Demo/platform/glfw_extra_win.cpp
@@ -25,7 +25,7 @@ void CreateTimerWindow()
 {
 	// Set up and register window class
 	memset(&wndclass, 0, sizeof(WNDCLASS));
-	wndclass.lpfnWndProc = TimerProc;
+	wndclass.lpfnWndProc = (WNDPROC)TimerProc;
 	wndclass.lpszMenuName = "TB_TIMER_WINDOW";
 	wndclass.lpszClassName = "TB_TIMER_WINDOW";
 	RegisterClass((WNDCLASS*)&wndclass);

--- a/Demo/platform/port_glfw.cpp
+++ b/Demo/platform/port_glfw.cpp
@@ -212,7 +212,7 @@ static void key_callback(GLFWwindow *window, int key, int scancode, int action, 
 	case GLFW_KEY_TAB:			InvokeKey(window, 0, TB_KEY_TAB, modifier, down); break;
 	case GLFW_KEY_DELETE:		InvokeKey(window, 0, TB_KEY_DELETE, modifier, down); break;
 	case GLFW_KEY_BACKSPACE:	InvokeKey(window, 0, TB_KEY_BACKSPACE, modifier, down); break;
-	case GLFW_KEY_ENTER:		
+	case GLFW_KEY_ENTER:
 	case GLFW_KEY_KP_ENTER:		InvokeKey(window, 0, TB_KEY_ENTER, modifier, down); break;
 	case GLFW_KEY_ESCAPE:		InvokeKey(window, 0, TB_KEY_ESC, modifier, down); break;
 	case GLFW_KEY_MENU:
@@ -448,7 +448,7 @@ bool ApplicationBackendGLFW::Init(Application *app, int width, int height, const
 	m_application = app;
 	m_application->OnBackendAttached(this);
 
-#ifdef TB_TARGET_MACOSX
+#ifdef TB_TARGET_MACOSX && !defined(TB_USE_CURRENT_DIRECTORY)
 	// Initializing glfw put us in Resources sub directory.
 	chdir("../");
 #endif
@@ -483,7 +483,7 @@ void ApplicationBackendGLFW::Run()
 #include <mmsystem.h>
 int PASCAL WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
-#if !defined(USE_CURRENT_DIRECTORY)
+#if !defined(TB_USE_CURRENT_DIRECTORY)
 	// Set the current path to the directory of the app so we find assets also when visual studio start it.
 	char modname[MAX_PATH];
 	GetModuleFileName(NULL, modname, MAX_PATH);

--- a/Demo/platform/port_glfw.cpp
+++ b/Demo/platform/port_glfw.cpp
@@ -448,7 +448,7 @@ bool ApplicationBackendGLFW::Init(Application *app, int width, int height, const
 	m_application = app;
 	m_application->OnBackendAttached(this);
 
-#ifdef TB_TARGET_MACOSX && !defined(TB_USE_CURRENT_DIRECTORY)
+#if defined(TB_TARGET_MACOSX) && !defined(TB_USE_CURRENT_DIRECTORY)
 	// Initializing glfw put us in Resources sub directory.
 	chdir("../");
 #endif

--- a/Demo/platform/port_glfw.cpp
+++ b/Demo/platform/port_glfw.cpp
@@ -483,12 +483,14 @@ void ApplicationBackendGLFW::Run()
 #include <mmsystem.h>
 int PASCAL WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
+#if !defined(USE_CURRENT_DIRECTORY)
 	// Set the current path to the directory of the app so we find assets also when visual studio start it.
 	char modname[MAX_PATH];
 	GetModuleFileName(NULL, modname, MAX_PATH);
 	TBTempBuffer buf;
 	buf.AppendPath(modname);
 	SetCurrentDirectory(buf.GetData());
+#endif
 
 	// Crank up windows timer resolution (it's awfully low res normally). Note: This affects battery time!
     timeBeginPeriod(1);

--- a/src/tb/renderers/tb_renderer_gl.cpp
+++ b/src/tb/renderers/tb_renderer_gl.cpp
@@ -5,9 +5,12 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include "tb_types.h"
 #include "tb_renderer_gl.h"
 #include "tb_bitmap_fragment.h"
 #include "tb_system.h"
+
+#if defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)
 
 namespace tb {
 
@@ -162,3 +165,4 @@ void TBRendererGL::SetClipRect(const TBRect &rect)
 }
 
 }; // namespace tb
+#endif // defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)

--- a/src/tb/renderers/tb_renderer_gl.h
+++ b/src/tb/renderers/tb_renderer_gl.h
@@ -6,6 +6,9 @@
 #ifndef TB_RENDERER_GL_H
 #define TB_RENDERER_GL_H
 
+#include "renderers/tb_renderer_batcher.h"
+
+#if defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)
 #ifdef TB_RENDERER_GLES_1
 #include <EGL/egl.h>
 #include <GLES/gl.h>
@@ -19,8 +22,6 @@
 #else
 #include <GL/gl.h>
 #endif
-
-#include "renderers/tb_renderer_batcher.h"
 
 namespace tb {
 
@@ -62,4 +63,5 @@ public:
 
 }; // namespace tb
 
+#endif // defined(TB_RENDERER_GLES_1) || defined(TB_RENDERER_GL)
 #endif // TB_RENDERER_GL_H

--- a/src/tb/tb_list.cpp
+++ b/src/tb/tb_list.cpp
@@ -7,7 +7,9 @@
 #include "tb_core.h"
 #include <assert.h>
 #include <stdlib.h>
+#if !defined(__native_client__)
 #include <memory.h>
+#endif
 
 namespace tb {
 

--- a/src/tb/tb_tempbuffer.cpp
+++ b/src/tb/tb_tempbuffer.cpp
@@ -6,7 +6,9 @@
 #include "tb_tempbuffer.h"
 #include <assert.h>
 #include <stdlib.h>
+#if !defined(__native_client__)
 #include <memory.h>
+#endif
 #include <string.h>
 
 namespace tb {


### PR DESCRIPTION
To get turbobadger building and running correctly with [fips](http://github.com/fungos/fips-turbobadger) build system we had to do some minor changes:

* Added a check for define TB_USE_CURRENT_DIRECTORY to disable changing automatically the current workdir, so that when running demo application with fips run command it can find the assets as the executable is not in the same directory as the assets but will be run using it as working directory. This define will only exist on builds created from the fips project and should not affect the original build and resulting demo.
* Includes some GL fixes for compiling for PNaCL (Google's Native Client).
* Fixes an WNDPROC missing cast when building on 64bits.