### PR TITLE
Added CMake options for selecting font rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project(TurboBadger)
 cmake_minimum_required(VERSION 2.8)
 
 option(TB_BUILD_DEMO "Build the Demo application. Depends on glfw." ON)
+option(TB_USE_FREETYPE "Use Freetype font rendering" OFF)
+option(TB_USE_TBBF "Use Turbo Badger bitmap font rendering" ON)
 
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x -fno-exceptions -fno-rtti -Wall -Wextra -Wno-unused-parameter")

--- a/Demo/demo01/Demo01.cpp
+++ b/Demo/demo01/Demo01.cpp
@@ -872,10 +872,10 @@ void DemoApplication::OnBackendAttached(AppBackend *backend, int width, int heig
 
 	// Set the default font description for widgets to one of the fonts we just added
 	TBFontDescription fd;
-#ifdef TB_FONT_RENDERER_TBBF
-	fd.SetID(TBIDC("Segoe"));
+#ifdef TB_FONT_RENDERER_FREETYPE
+    fd.SetID(TBIDC("Vera"));
 #else
-	fd.SetID(TBIDC("Vera"));
+    fd.SetID(TBIDC("Segoe"));
 #endif
 	fd.SetSize(g_tb_skin->GetDimensionConverter()->DpToPx(14));
 	g_font_manager->SetDefaultFontDescription(fd);

--- a/src/tb/CMakeLists.txt
+++ b/src/tb/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+configure_file(${CMAKE_CURRENT_LIST_DIR}/tb_config.h.in ${CMAKE_CURRENT_LIST_DIR}/tb_config.h)
+
 set(LOCAL_SRCS "")
 aux_source_directory(. LOCAL_SRCS)
 aux_source_directory(image LOCAL_SRCS)
@@ -10,3 +12,9 @@ aux_source_directory(tests LOCAL_SRCS)
 aux_source_directory(utf8 LOCAL_SRCS)
 
 add_library(TurboBadgerLib ${LOCAL_SRCS})
+
+if(TB_USE_FREETYPE)
+	find_package(Freetype REQUIRED)
+	include_directories(${FREETYPE_INCLUDE_DIRS})
+	target_link_libraries(TurboBadgerLib ${FREETYPE_LIBRARIES})
+endif()

--- a/src/tb/tb_config.h.in
+++ b/src/tb/tb_config.h.in
@@ -31,11 +31,17 @@
 	the default backends, so consider it an experimental and unfinished feature! */
 //#define TB_PREMULTIPLIED_ALPHA
 
+#cmakedefine01 TB_USE_TBBF
+#if TB_USE_TBBF
 /** Enable to support TBBF fonts (Turbo Badger Bitmap Fonts) */
 #define TB_FONT_RENDERER_TBBF
+#endif
 
+#cmakedefine01 TB_USE_FREETYPE
+#if TB_USE_FREETYPE
 /** Enable to support truetype fonts using freetype. */
-//#define TB_FONT_RENDERER_FREETYPE
+#define TB_FONT_RENDERER_FREETYPE
+#endif
 
 /** Enable to support truetype fonts using stb_truetype.h (http://nothings.org/).
 	It's a *very unsafe* font library. Use only with fonts distributed with your


### PR DESCRIPTION
This patch makes it a bit easier to switch between Freetype and TBBF font rendering by adding two options to CMake (TB_USE_FREETYPE and TB_USE_TBBF).
