### PR TITLE
fixed compilation with gcc 6.1.1

### DIFF
--- a/src/tb/tb_image_loader_stb.cpp
+++ b/src/tb/tb_image_loader_stb.cpp
@@ -9,8 +9,6 @@
 
 #ifdef TB_IMAGE_LOADER_STB
 
-namespace tb {
-
 // Configure stb image and remove some features we don't use to reduce binary size.
 #define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
@@ -30,6 +28,8 @@ namespace tb {
 #include "thirdparty/stb_image.h"
 
 #pragma GCC diagnostic pop
+
+namespace tb {
 
 class STBI_Loader : public TBImageLoader
 {


### PR DESCRIPTION
```
                 from /home/mgerhardy/turbobadger/tb/tb_image_loader_stb.cpp:30:
/usr/include/c++/6/cstdlib:124:11: error: ‘::div_t’ has not been declared
   using ::div_t;
           ^~~~~
/usr/include/c++/6/cstdlib:125:11: error: ‘::ldiv_t’ has not been declared
   using ::ldiv_t;
           ^~~~~~
/usr/include/c++/6/cstdlib:127:11: error: ‘::abort’ has not been declared
   using ::abort;
           ^~~~~
/usr/include/c++/6/cstdlib:128:11: error: ‘::abs’ has not been declared
   using ::abs;
           ^~~
/usr/include/c++/6/cstdlib:129:11: error: ‘::atexit’ has not been declared
   using ::atexit;
           ^~~~~~
/usr/include/c++/6/cstdlib:132:11: error: ‘::at_quick_exit’ has not been declared
   using ::at_quick_exit;
           ^~~~~~~~~~~~~
/usr/include/c++/6/cstdlib:135:11: error: ‘::atof’ has not been declared
   using ::atof;
           ^~~~
/usr/include/c++/6/cstdlib:136:11: error: ‘::atoi’ has not been declared
   using ::atoi;
           ^~~~
/usr/include/c++/6/cstdlib:137:11: error: ‘::atol’ has not been declared
   using ::atol;
```