### PR TITLE
Fix TBImage::IsEmpty

### DIFF
--- a/src/tb/image/tb_image_manager.cpp
+++ b/src/tb/image/tb_image_manager.cpp
@@ -60,7 +60,7 @@ TBImage::~TBImage()
 
 bool TBImage::IsEmpty() const
 {
-	return m_image_rep && m_image_rep->fragment;
+	return !(m_image_rep && m_image_rep->fragment);
 }
 
 int TBImage::Width() const


### PR DESCRIPTION
It was returning whether it was not empty instead of whether it was empty, like the name implies.
